### PR TITLE
Add LICENSE to the built wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The wheel released on Pypi does not include the `LICENSE` file. This fixes it here too.
